### PR TITLE
feat: redesign desk theme with apple aesthetic

### DIFF
--- a/ravan_ui/hooks.py
+++ b/ravan_ui/hooks.py
@@ -51,7 +51,7 @@ app_include_js = "/assets/ravan_ui/js/ravan_ui.js"
 # Svg Icons
 # ------------------
 # include app icons in desk
-# app_include_icons = "ravan_ui/public/icons.svg"
+app_include_icons = "ravan_ui/public/icons.svg"
 
 # Home Pages
 # ----------

--- a/ravan_ui/public/css/theme.css
+++ b/ravan_ui/public/css/theme.css
@@ -1,85 +1,473 @@
 @import url('variables.css');
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap');
+
+:root {
+    color-scheme: light dark;
+}
 
 body,
 .frappe-container {
-    font-family: var(--font-family-sans-serif) !important;
-    background-color: var(--background-color) !important;
-    color: var(--text-color) !important;
-    transition: background-color 0.3s, color 0.3s;
+    font-family: var(--font-sans) !important;
+    background-color: var(--surface-window) !important;
+    color: var(--text-primary) !important;
+    transition: background-color var(--motion-duration-base) var(--motion-ease-standard),
+        color var(--motion-duration-base) var(--motion-ease-standard);
+    min-height: 100vh;
 }
 
-/* Navbar */
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(120% 120% at 50% 0%, rgba(10, 132, 255, 0.15), transparent 60%),
+        radial-gradient(90% 140% at 0% 40%, rgba(255, 159, 10, 0.12), transparent 70%);
+    opacity: 0.7;
+    mix-blend-mode: screen;
+    z-index: 0;
+}
+
+body[data-theme="dark"]::before,
+:root[data-theme="dark"] body::before {
+    mix-blend-mode: lighten;
+    opacity: 0.35;
+}
+
+body .frappe-container,
+.frappe-container .page-container,
+.frappe-container .page-wrapper {
+    position: relative;
+    z-index: 1;
+}
+
+body a,
+.frappe-container a {
+    color: var(--accent-color);
+    text-decoration: none;
+    transition: color var(--motion-duration-rapid) var(--motion-ease-standard);
+}
+
+a:hover,
+a:focus {
+    color: var(--accent-color-strong);
+}
+
+::selection {
+    background: var(--selection-color);
+    color: var(--text-primary);
+}
+
+/* Layout scaffolding */
+.navbar,
+.page-head,
+.layout-main-section,
+.sidebar,
+.layout-side-section,
+.list-sidebar {
+    backdrop-filter: blur(var(--surface-blur));
+    -webkit-backdrop-filter: blur(var(--surface-blur));
+}
+
 .navbar {
-    background-color: var(--card-bg) !important;
-    border-bottom: 1px solid var(--border-color) !important;
-    box-shadow: var(--card-shadow) !important;
+    background-color: var(--surface-translucent) !important;
+    border-bottom: var(--border-width-hairline) solid var(--surface-border) !important;
+    box-shadow: var(--shadow-soft);
+    min-height: 54px;
 }
 
 .navbar .navbar-brand .app-logo,
 .navbar .navbar-brand .app-logo-text {
-    color: var(--text-color) !important;
+    color: var(--text-primary) !important;
+    letter-spacing: -0.01em;
+    font-weight: 600;
+}
+
+.navbar .navbar-nav > li > a,
+.navbar .btn,
+.navbar .nav-item .btn {
+    border-radius: var(--control-radius-sm) !important;
+    color: var(--text-secondary) !important;
+    transition: background-color var(--motion-duration-rapid) var(--motion-ease-standard),
+        color var(--motion-duration-rapid) var(--motion-ease-standard),
+        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard);
+}
+
+.navbar .navbar-nav > li > a:hover,
+.navbar .btn:hover,
+.navbar .nav-item .btn:hover {
+    background: var(--icon-container-active) !important;
+    color: var(--text-primary) !important;
 }
 
 /* Sidebar */
 .sidebar {
-    background-color: var(--card-bg) !important;
-    border-right: 1px solid var(--border-color) !important;
+    width: var(--sidebar-width);
+    background: var(--surface-sidebar) !important;
+    border-right: var(--border-width-hairline) solid var(--surface-border) !important;
+    padding: 20px 18px;
+    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04);
+}
+
+.sidebar .standard-sidebar-header {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+}
+
+.sidebar .sidebar-item {
+    margin-bottom: 4px;
 }
 
 .sidebar .sidebar-item .sidebar-link {
-    color: var(--text-color-light) !important;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: var(--control-radius-sm);
+    color: var(--text-secondary) !important;
+    transition: background-color var(--motion-duration-rapid) var(--motion-ease-standard),
+        color var(--motion-duration-rapid) var(--motion-ease-standard),
+        transform var(--motion-duration-rapid) var(--motion-ease-emphasized);
 }
 
+.sidebar .sidebar-item .sidebar-link:focus,
 .sidebar .sidebar-item .sidebar-link:hover {
-    background-color: var(--background-color-light) !important;
-    color: var(--text-color) !important;
+    background: var(--surface-sidebar-active) !important;
+    color: var(--text-primary) !important;
 }
 
-/* Workspace */
-.workspace-page .card-list .card,
-.workspace-page .widget {
-    background-color: var(--card-bg) !important;
-    border: 1px solid var(--card-border-color) !important;
-    box-shadow: var(--card-shadow) !important;
-    border-radius: 8px !important;
-    transition: all 0.3s;
+.sidebar .sidebar-item.active .sidebar-link {
+    background: var(--surface-sidebar-active) !important;
+    color: var(--text-primary) !important;
+    box-shadow: 0 1px 3px rgba(10, 132, 255, 0.18);
+}
+
+.sidebar .sidebar-section + .sidebar-section {
+    margin-top: 20px;
+}
+
+.ravan-ui-icon {
+    width: 28px;
+    height: 28px;
+    flex: 0 0 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9px;
+    background: var(--icon-container);
+    color: var(--accent-color);
+    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
+        color var(--motion-duration-rapid) var(--motion-ease-standard);
+}
+
+.sidebar .sidebar-item.active .ravan-ui-icon,
+.sidebar .sidebar-item .sidebar-link:hover .ravan-ui-icon {
+    background: var(--icon-container-active);
+    color: var(--accent-color-strong);
+}
+
+.ravan-ui-icon svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
+
+/* Workspace cards & widgets */
+.workspace-page .card,
+.workspace-page .widget,
+.list-sidebar .sidebar-stat,
+.desk-sidebar .shortcut-card,
+.page-card,
+.widget {
+    background: var(--surface-raised) !important;
+    border: var(--border-width-hairline) solid var(--surface-border) !important;
+    border-radius: var(--control-radius-lg) !important;
+    box-shadow: var(--shadow-floating) !important;
+    transition: transform var(--motion-duration-rapid) var(--motion-ease-emphasized),
+        box-shadow var(--motion-duration-base) var(--motion-ease-standard),
+        border-color var(--motion-duration-base) var(--motion-ease-standard);
+}
+
+.workspace-page .card:hover,
+.workspace-page .widget:hover,
+.desk-sidebar .shortcut-card:hover,
+.widget:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-raised) !important;
+    border-color: rgba(10, 132, 255, 0.18) !important;
+}
+
+.workspace-page .card .card-title,
+.workspace-page .card .widget-title,
+.widget .widget-title,
+.section-head {
+    font-family: var(--font-sans-condensed) !important;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text-primary) !important;
+}
+
+.ravan-ui-elevated {
+    position: relative;
+    overflow: hidden;
+}
+
+.ravan-ui-elevated::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+    opacity: 0;
+    transition: opacity var(--motion-duration-base) var(--motion-ease-standard);
+    pointer-events: none;
+}
+
+.ravan-ui-elevated:hover::after {
+    opacity: 1;
+}
+
+.badge,
+.indicator-pill,
+.list-tags .badge {
+    background: var(--badge-background) !important;
+    color: var(--text-secondary) !important;
+    border: none !important;
+    border-radius: var(--control-radius-sm) !important;
+    padding: 4px 10px !important;
 }
 
 /* Buttons */
-.btn-primary {
-    background-image: linear-gradient(to right, var(--primary-color) 0%, var(--primary-color-hover) 100%) !important;
-    color: var(--button-text-color) !important;
-    border: none !important;
-    transition: all 0.4s ease-in-out !important;
-    background-size: 200% auto !important;
+.btn,
+.form-group .btn,
+.page-actions .btn {
+    border-radius: var(--control-radius) !important;
+    font-weight: 600 !important;
+    letter-spacing: -0.01em;
+    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
+        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard),
+        transform var(--motion-duration-rapid) var(--motion-ease-standard);
 }
 
-.btn-primary:hover {
-    background-position: right center !important;
+.btn-primary,
+.btn.btn-primary {
+    background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-strong) 100%) !important;
+    color: var(--accent-on-accent) !important;
+    border: none !important;
+    box-shadow: var(--accent-shadow) !important;
+}
+
+.btn-primary:hover,
+.btn.btn-primary:hover {
+    transform: translateY(-1px);
+    filter: saturate(110%);
+}
+
+.btn-secondary,
+.btn-default,
+.btn-light {
+    background: var(--icon-container) !important;
+    color: var(--text-primary) !important;
+    border: var(--border-width-hairline) solid var(--surface-border) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.btn-secondary:hover,
+.btn-default:hover,
+.btn-light:hover {
+    background: var(--icon-container-active) !important;
 }
 
 /* Forms */
 .form-control,
-.form-select {
-    background-color: var(--input-bg) !important;
-    border: 1px solid var(--input-border-color) !important;
-    color: var(--text-color) !important;
-    transition: all 0.3s;
+.form-select,
+.input-with-feedback,
+.control-input {
+    background: var(--input-background) !important;
+    border: var(--border-width-hairline) solid var(--input-border) !important;
+    border-radius: var(--control-radius) !important;
+    box-shadow: var(--input-shadow);
+    color: var(--text-primary) !important;
+    transition: border-color var(--motion-duration-rapid) var(--motion-ease-standard),
+        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard),
+        background var(--motion-duration-rapid) var(--motion-ease-standard);
+    padding: 10px 14px !important;
 }
 
 .form-control:focus,
-.form-select:focus {
-    background-color: var(--input-focus-bg) !important;
-    border-color: var(--input-focus-border-color) !important;
+.form-select:focus,
+.input-with-feedback:focus,
+.control-input:focus {
+    border-color: var(--input-border-active) !important;
+    box-shadow: 0 0 0 4px var(--accent-color-soft);
+    outline: none !important;
 }
 
-/* Hide Help from Navbar */
-.navbar .dropdown-help {
-    display: none !important;
+label,
+.form-label,
+.control-label {
+    color: var(--text-secondary) !important;
+    font-weight: 500;
 }
 
-/* Hide ERPNext Integrations from Sidebar */
+/* Tables & list view */
+.list-row,
+.report-table tbody tr,
+.table tbody tr {
+    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
+        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard);
+    border-radius: var(--control-radius-sm);
+}
+
+.list-row:hover,
+.report-table tbody tr:hover,
+.table tbody tr:hover {
+    background: var(--table-row-hover) !important;
+}
+
+.list-row-head,
+.report-table thead th,
+.table thead th {
+    font-weight: 600;
+    color: var(--text-secondary) !important;
+    background: transparent !important;
+    border-bottom: var(--border-width) solid var(--surface-divider) !important;
+}
+
+.list-row-container {
+    gap: 6px;
+}
+
+/* Dialogs & popovers */
+.modal,
+.dropdown-menu,
+.datepicker,
+.popover {
+    background: var(--surface-popover) !important;
+    border: var(--border-width-hairline) solid var(--surface-border-strong) !important;
+    border-radius: var(--control-radius-lg) !important;
+    box-shadow: var(--shadow-raised) !important;
+    backdrop-filter: blur(var(--surface-blur));
+    -webkit-backdrop-filter: blur(var(--surface-blur));
+}
+
+.modal-header,
+.modal-footer {
+    border-color: var(--surface-divider) !important;
+}
+
+.modal-title {
+    font-weight: 600;
+    color: var(--text-primary) !important;
+}
+
+.dropdown-item {
+    border-radius: var(--control-radius-sm);
+    color: var(--text-secondary);
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus {
+    background: var(--surface-sidebar-active);
+    color: var(--text-primary);
+}
+
+/* Alerts & notifications */
+.alert {
+    border-radius: var(--control-radius) !important;
+    border: none !important;
+    box-shadow: var(--shadow-floating);
+}
+
+.alert-info {
+    background: rgba(10, 132, 255, 0.16) !important;
+    color: var(--text-primary) !important;
+}
+
+.alert-warning {
+    background: rgba(255, 159, 10, 0.22) !important;
+    color: var(--text-primary) !important;
+}
+
+.alert-danger {
+    background: rgba(255, 69, 58, 0.24) !important;
+    color: var(--text-primary) !important;
+}
+
+.alert-success {
+    background: rgba(48, 209, 88, 0.18) !important;
+    color: var(--text-primary) !important;
+}
+
+/* Quick lists & pills */
+.list-sidebar .list-sidebar-item,
+.list-paging-area .btn,
+.indicator-pill {
+    border-radius: var(--control-radius-sm) !important;
+}
+
+.indicator-pill.orange {
+    background: rgba(255, 159, 10, 0.16) !important;
+    color: var(--accent-on-accent) !important;
+}
+
+.indicator-pill.green {
+    background: rgba(48, 209, 88, 0.2) !important;
+    color: #0a2f14 !important;
+}
+
+/* Kanban cards */
+.kanban-card,
+.task-card {
+    background: var(--surface-raised) !important;
+    border-radius: var(--control-radius-lg) !important;
+    border: var(--border-width-hairline) solid var(--surface-border) !important;
+    box-shadow: var(--shadow-soft) !important;
+}
+
+.kanban-card:hover,
+.task-card:hover {
+    box-shadow: var(--shadow-floating) !important;
+}
+
+/* Login & onboarding */
+.login-content,
+.for-login .page-card {
+    background: var(--surface-raised) !important;
+    border-radius: var(--control-radius-lg) !important;
+    border: var(--border-width-hairline) solid var(--surface-border) !important;
+    box-shadow: var(--shadow-floating) !important;
+}
+
+/* Utility */
+.table > :not(caption) > * > * {
+    background-color: transparent !important;
+}
+
+code,
+pre,
+.monospace {
+    font-family: var(--font-mono) !important;
+}
+
+hr {
+    border-top: var(--border-width) solid var(--surface-divider) !important;
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+    .navbar,
+    .sidebar,
+    .page-head,
+    .layout-side-section,
+    .list-sidebar {
+        background-color: var(--surface-raised) !important;
+    }
+}
+
+/* Hide legacy chrome */
+.navbar .dropdown-help,
 .sidebar-item a[title="ERPNext Integrations"] {
     display: none !important;
 }

--- a/ravan_ui/public/css/variables.css
+++ b/ravan_ui/public/css/variables.css
@@ -1,78 +1,180 @@
 :root {
-    --font-family-sans-serif: 'Ubuntu', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-family-monospace: 'Ubuntu Mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --font-sans-condensed: "SF Pro Display", "SF Pro Rounded", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-mono: "SFMono-Regular", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+    --motion-duration-rapid: 160ms;
+    --motion-duration-base: 220ms;
+    --motion-duration-slow: 360ms;
+    --motion-ease-standard: cubic-bezier(0.22, 0.61, 0.36, 1);
+    --motion-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
+
+    --shadow-raised: 0 30px 60px rgba(15, 23, 42, 0.18);
+    --shadow-floating: 0 18px 40px rgba(15, 23, 42, 0.14);
+    --shadow-soft: 0 1px 3px rgba(15, 23, 42, 0.08);
+
+    --surface-blur: 26px;
+    --border-width-hairline: 0.5px;
+    --border-width: 1px;
+
+    --control-radius-sm: 10px;
+    --control-radius: 12px;
+    --control-radius-lg: 18px;
+
+    --density-tight: 12px;
+    --density-regular: 16px;
+    --density-loose: 24px;
+
+    --sidebar-width: 268px;
+
+    --accent-color: #0a84ff;
+    --accent-color-strong: #0060df;
+    --accent-color-soft: rgba(10, 132, 255, 0.16);
+    --accent-on-accent: #ffffff;
+    --accent-shadow: 0 0 0 1px rgba(10, 132, 255, 0.18), 0 10px 24px rgba(10, 132, 255, 0.24);
+    --surface-window: #f5f6f9;
+    --surface-base: rgba(255, 255, 255, 0.86);
+    --surface-raised: rgba(255, 255, 255, 0.92);
+    --surface-popover: rgba(255, 255, 255, 0.97);
+    --surface-translucent: rgba(255, 255, 255, 0.76);
+    --surface-divider: rgba(60, 60, 67, 0.18);
+    --surface-divider-strong: rgba(60, 60, 67, 0.28);
+    --surface-border: rgba(30, 41, 59, 0.12);
+    --surface-border-strong: rgba(30, 41, 59, 0.24);
+    --surface-sidebar: rgba(246, 247, 250, 0.84);
+    --surface-sidebar-active: rgba(10, 132, 255, 0.12);
+
+    --text-primary: rgba(17, 17, 17, 0.92);
+    --text-secondary: rgba(60, 60, 67, 0.72);
+    --text-tertiary: rgba(60, 60, 67, 0.5);
+    --text-quaternary: rgba(60, 60, 67, 0.32);
+    --text-inverse: rgba(255, 255, 255, 0.94);
+
+    --input-background: rgba(255, 255, 255, 0.68);
+    --input-border: rgba(30, 41, 59, 0.12);
+    --input-border-active: rgba(10, 132, 255, 0.6);
+    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 2px rgba(15, 23, 42, 0.12);
+
+    --table-row-hover: rgba(10, 132, 255, 0.08);
+    --pill-background: rgba(60, 60, 67, 0.12);
+    --badge-background: rgba(60, 60, 67, 0.14);
+
+    --icon-container: rgba(60, 60, 67, 0.08);
+    --icon-container-active: rgba(10, 132, 255, 0.14);
+
+    --selection-color: rgba(10, 132, 255, 0.14);
+    --selection-outline: rgba(10, 132, 255, 0.28);
+
+[data-accent="blue"] {
+    --accent-color: #0a84ff;
+    --accent-color-strong: #0060df;
+    --accent-color-soft: rgba(10, 132, 255, 0.16);
+    --accent-on-accent: #ffffff;
+    --accent-shadow: 0 0 0 1px rgba(10, 132, 255, 0.18), 0 10px 24px rgba(10, 132, 255, 0.24);
+}
+
+[data-accent="green"] {
+    --accent-color: #30d158;
+    --accent-color-strong: #248a3d;
+    --accent-color-soft: rgba(48, 209, 88, 0.18);
+    --accent-on-accent: #031d0b;
+    --accent-shadow: 0 0 0 1px rgba(48, 209, 88, 0.18), 0 10px 24px rgba(48, 209, 88, 0.24);
+}
+
+[data-accent="orange"] {
+    --accent-color: #ff9f0a;
+    --accent-color-strong: #c36a00;
+    --accent-color-soft: rgba(255, 159, 10, 0.2);
+    --accent-on-accent: #2b1700;
+    --accent-shadow: 0 0 0 1px rgba(255, 159, 10, 0.24), 0 10px 24px rgba(255, 159, 10, 0.28);
+}
+
+[data-accent="pink"] {
+    --accent-color: #ff2d55;
+    --accent-color-strong: #c01333;
+    --accent-color-soft: rgba(255, 45, 85, 0.18);
+    --accent-on-accent: #2a030a;
+    --accent-shadow: 0 0 0 1px rgba(255, 45, 85, 0.22), 0 10px 24px rgba(255, 45, 85, 0.3);
 }
 
 [data-theme="light"] {
-    --primary-color: #4e0091;
-    --primary-color-hover: #3a006a;
-    --primary-color-light: #f2e6ff;
-    --primary-color-light-hover: #e6d9f2;
+    --surface-window: #f5f6f9;
+    --surface-base: rgba(255, 255, 255, 0.86);
+    --surface-raised: rgba(255, 255, 255, 0.92);
+    --surface-popover: rgba(255, 255, 255, 0.97);
+    --surface-translucent: rgba(255, 255, 255, 0.76);
+    --surface-divider: rgba(60, 60, 67, 0.18);
+    --surface-divider-strong: rgba(60, 60, 67, 0.28);
+    --surface-border: rgba(30, 41, 59, 0.12);
+    --surface-border-strong: rgba(30, 41, 59, 0.24);
+    --surface-sidebar: rgba(246, 247, 250, 0.84);
+    --surface-sidebar-active: rgba(10, 132, 255, 0.12);
 
-    --text-color: #212529;
-    --text-color-light: #5a5a5a;
-    --text-color-muted: #8d8d8d;
+    --text-primary: rgba(17, 17, 17, 0.92);
+    --text-secondary: rgba(60, 60, 67, 0.72);
+    --text-tertiary: rgba(60, 60, 67, 0.5);
+    --text-quaternary: rgba(60, 60, 67, 0.32);
+    --text-inverse: rgba(255, 255, 255, 0.94);
 
-    --background-color: #ffffff;
-    --background-color-light: #f0f2f5;
-    --background-color-dark: #e9ecef;
+    --input-background: rgba(255, 255, 255, 0.68);
+    --input-border: rgba(30, 41, 59, 0.12);
+    --input-border-active: rgba(10, 132, 255, 0.6);
+    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 2px rgba(15, 23, 42, 0.12);
 
-    --border-color: #dee2e6;
-    --border-color-light: #f1f1f1;
+    --table-row-hover: rgba(10, 132, 255, 0.08);
+    --pill-background: rgba(60, 60, 67, 0.12);
+    --badge-background: rgba(60, 60, 67, 0.14);
 
-    --card-bg: #ffffff;
-    --card-border-color: var(--border-color);
-    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    --icon-container: rgba(60, 60, 67, 0.08);
+    --icon-container-active: rgba(10, 132, 255, 0.14);
 
-    --button-bg: var(--primary-color);
-    --button-text-color: #ffffff;
-    --button-hover-bg: var(--primary-color-hover);
-
-    --input-bg: #fdfdfd;
-    --input-border-color: #ced4da;
-    --input-focus-bg: #ffffff;
-    --input-focus-border-color: var(--primary-color);
-
-    --modal-bg: #ffffff;
-    --modal-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-
-    --link-color: var(--primary-color);
-    --link-hover-color: var(--primary-color-hover);
+    --selection-color: rgba(10, 132, 255, 0.14);
+    --selection-outline: rgba(10, 132, 255, 0.28);
 }
 
 [data-theme="dark"] {
-    --primary-color: #9d4edd;
-    --primary-color-hover: #b370f2;
-    --primary-color-light: #3c1e5b;
-    --primary-color-light-hover: #4a2a6f;
+    --surface-window: #050509;
+    --surface-base: rgba(28, 28, 30, 0.82);
+    --surface-raised: rgba(37, 37, 39, 0.82);
+    --surface-popover: rgba(44, 44, 46, 0.88);
+    --surface-translucent: rgba(29, 29, 31, 0.76);
+    --surface-divider: rgba(84, 84, 88, 0.3);
+    --surface-divider-strong: rgba(199, 199, 204, 0.28);
+    --surface-border: rgba(255, 255, 255, 0.08);
+    --surface-border-strong: rgba(255, 255, 255, 0.18);
+    --surface-sidebar: rgba(22, 22, 24, 0.78);
+    --surface-sidebar-active: rgba(10, 132, 255, 0.22);
 
-    --text-color: #e0e0e0;
-    --text-color-light: #b0b0b0;
-    --text-color-muted: #7e7e7e;
+    --text-primary: rgba(255, 255, 255, 0.92);
+    --text-secondary: rgba(235, 235, 245, 0.66);
+    --text-tertiary: rgba(235, 235, 245, 0.42);
+    --text-quaternary: rgba(235, 235, 245, 0.28);
+    --text-inverse: rgba(17, 17, 17, 0.92);
 
-    --background-color: #121212;
-    --background-color-light: #2a2a2a;
-    --background-color-dark: #2c2c2c;
+    --input-background: rgba(44, 44, 46, 0.68);
+    --input-border: rgba(255, 255, 255, 0.06);
+    --input-border-active: rgba(10, 132, 255, 0.7);
+    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 2px rgba(0, 0, 0, 0.4);
 
-    --border-color: #3c3c3c;
-    --border-color-light: #2a2a2a;
+    --table-row-hover: rgba(10, 132, 255, 0.18);
+    --pill-background: rgba(235, 235, 245, 0.16);
+    --badge-background: rgba(235, 235, 245, 0.18);
 
-    --card-bg: #1e1e1e;
-    --card-border-color: var(--border-color);
-    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.24), 0 1px 2px rgba(0, 0, 0, 0.48);
+    --icon-container: rgba(235, 235, 245, 0.12);
+    --icon-container-active: rgba(10, 132, 255, 0.26);
 
-    --button-bg: var(--primary-color);
-    --button-text-color: #ffffff;
-    --button-hover-bg: var(--primary-color-hover);
+    --selection-color: rgba(10, 132, 255, 0.24);
+    --selection-outline: rgba(10, 132, 255, 0.38);
+}
 
-    --input-bg: #252525;
-    --input-border-color: #495057;
-    --input-focus-bg: #2c2c2c;
-    --input-focus-border-color: var(--primary-color);
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        color-scheme: dark;
+    }
+}
 
-    --modal-bg: #1e1e1e;
-    --modal-shadow: 0 5px 15px rgba(0, 0, 0, 0.7);
-
-    --link-color: var(--primary-color);
-    --link-hover-color: var(--primary-color-hover);
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) {
+        color-scheme: light;
+    }
 }

--- a/ravan_ui/public/icons.svg
+++ b/ravan_ui/public/icons.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+    <symbol id="icon-house" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 11.5L12 4l9 7.5" />
+        <path d="M5.5 10V20h13V10" />
+        <path d="M9.5 20V14h5v6" />
+    </symbol>
+    <symbol id="icon-grid" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="4" y="4" width="6" height="6" rx="1.5" />
+        <rect x="14" y="4" width="6" height="6" rx="1.5" />
+        <rect x="4" y="14" width="6" height="6" rx="1.5" />
+        <rect x="14" y="14" width="6" height="6" rx="1.5" />
+    </symbol>
+    <symbol id="icon-ledger" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M6 4h9.5a2.5 2.5 0 012.5 2.5V20H6z" />
+        <path d="M6 4h-.5A1.5 1.5 0 004 5.5V18a2 2 0 002 2" />
+        <path d="M10 8h6" />
+        <path d="M10 12h6" />
+        <path d="M10 16h6" />
+    </symbol>
+    <symbol id="icon-bubble" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M6.5 17.5L4 20l.5-3.5A8 8 0 116.5 17.5z" />
+        <path d="M8 12h.01" />
+        <path d="M12 12h.01" />
+        <path d="M16 12h.01" />
+    </symbol>
+    <symbol id="icon-tag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M20 13.5L10.5 4H5a1 1 0 00-1 1v5.5L13.5 20a1 1 0 001.41 0L20 14.91a1 1 0 000-1.41z" />
+        <circle cx="8.5" cy="8.5" r="1.2" />
+    </symbol>
+    <symbol id="icon-bag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M6 7h12l1 13H5z" />
+        <path d="M9 7a3 3 0 116 0" />
+    </symbol>
+    <symbol id="icon-cubes" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z" />
+        <path d="M12 12l8-4.5" />
+        <path d="M12 12l-8-4.5" />
+        <path d="M12 12v9" />
+    </symbol>
+    <symbol id="icon-clipboard" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="6.5" y="4" width="11" height="16" rx="2.2" />
+        <path d="M9.5 4V3.5A1.5 1.5 0 0111 2h2a1.5 1.5 0 011.5 1.5V4" />
+        <path d="M9 9h6" />
+        <path d="M9 13h6" />
+    </symbol>
+    <symbol id="icon-people" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M16.5 11.5a3.5 3.5 0 10-3.5-3.5" />
+        <path d="M10 10a3.5 3.5 0 11-3.5-3.5" />
+        <path d="M3 19.4A6 6 0 019 15h0a6 6 0 016 4.4" />
+        <path d="M14 18.5a4.5 4.5 0 018 2.5" />
+    </symbol>
+    <symbol id="icon-banknote" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="7" width="18" height="10" rx="2.5" />
+        <circle cx="12" cy="12" r="2.5" />
+        <path d="M5 10h0" />
+        <path d="M19 14h0" />
+    </symbol>
+    <symbol id="icon-lifebuoy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <circle cx="12" cy="12" r="3.5" />
+        <path d="M4.5 4.5l3.3 3.3" />
+        <path d="M19.5 4.5l-3.3 3.3" />
+        <path d="M4.5 19.5l3.3-3.3" />
+        <path d="M19.5 19.5l-3.3-3.3" />
+    </symbol>
+    <symbol id="icon-shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 21s-7-3.5-7-10V6l7-3 7 3v5c0 6.5-7 10-7 10z" />
+        <path d="M9.5 11.5l2.5 2.5 3.5-3.5" />
+    </symbol>
+    <symbol id="icon-cube" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 3l7 4v8l-7 4-7-4V7z" />
+        <path d="M12 3v8" />
+        <path d="M19 7l-7 4-7-4" />
+    </symbol>
+    <symbol id="icon-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="2.5" />
+        <path d="M19.4 12.94a7.6 7.6 0 000-1.88l2-1.47-1.9-3.28-2.34.6a7.55 7.55 0 00-1.62-.94L15 3h-6l-.54 2.37c-.57.24-1.12.54-1.62.9l-2.34-.58-1.9 3.28 2 1.47a7.6 7.6 0 000 1.88l-2 1.47 1.9 3.28 2.34-.6c.5.37 1.05.68 1.62.94L9 21h6l.54-2.37c.57-.24 1.12-.54 1.62-.9l2.34.58 1.9-3.28z" />
+    </symbol>
+    <symbol id="icon-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M3 12h18" />
+        <path d="M12 3c2.5 3 3.75 6.5 3.75 9s-1.25 6-3.75 9c-2.5-3-3.75-6.5-3.75-9s1.25-6 3.75-9z" />
+    </symbol>
+    <symbol id="icon-cart" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 4h2l2.2 10.5a1.5 1.5 0 001.47 1.2H18.5a1.5 1.5 0 001.47-1.2L21 8H6" />
+        <circle cx="9" cy="19" r="1.5" />
+        <circle cx="18" cy="19" r="1.5" />
+    </symbol>
+    <symbol id="icon-chart" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M5 20V10" />
+        <path d="M12 20V4" />
+        <path d="M19 20v-7" />
+    </symbol>
+    <symbol id="icon-sliders" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 6h16" />
+        <path d="M4 12h16" />
+        <path d="M4 18h16" />
+        <circle cx="9" cy="6" r="2" />
+        <circle cx="15" cy="12" r="2" />
+        <circle cx="11" cy="18" r="2" />
+    </symbol>
+    <symbol id="icon-magic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10.5 3l.75 2.5L14 6.25l-2.75 1.25L10.5 10 9.25 7.5 6.5 6.25l2.75-.75z" />
+        <path d="M17.5 9.5l.5 1.5 1.5.5-1.5.5-.5 1.5-.5-1.5-1.5-.5 1.5-.5z" />
+        <path d="M4 20l8-8" />
+        <path d="M14 10l6 6" />
+    </symbol>
+    <symbol id="icon-puzzle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M9 3H5a2 2 0 00-2 2v4h1.5a2.5 2.5 0 110 5H3v4a2 2 0 002 2h4v-1.5a2.5 2.5 0 115 0V20h4a2 2 0 002-2v-4h-1.5a2.5 2.5 0 110-5H19V5a2 2 0 00-2-2h-4v1.5a2.5 2.5 0 11-5 0z" />
+    </symbol>
+</svg>

--- a/ravan_ui/public/js/ravan_ui.js
+++ b/ravan_ui/public/js/ravan_ui.js
@@ -1,43 +1,278 @@
-document.addEventListener('DOMContentLoaded', () => {
-    // A more robust way that also handles dynamically loaded content
-    const observer = new MutationObserver(mutations => {
-        mutations.forEach(mutation => {
-            if (mutation.addedNodes.length) {
-                replaceTextInSubtree(document.body);
-            }
-        });
-    });
+(() => {
+    'use strict';
 
-    const replaceTextInSubtree = (parentNode) => {
-        // Replace in text nodes
-        const walker = document.createTreeWalker(parentNode, NodeFilter.SHOW_TEXT);
-        let node;
-        while (node = walker.nextNode()) {
-            if (node.nodeValue.includes('ERPNEXT')) {
-                node.nodeValue = node.nodeValue.replace(/ERPNEXT/g, 'RavanOS');
-            }
-            if (node.nodeValue.includes('Frappe')) {
-                node.nodeValue = node.nodeValue.replace(/Frappe/g, 'Ravan');
-            }
-        }
+    const STORAGE_KEY = 'ravan-ui-preferences';
+    const DEFAULT_PREFS = { theme: 'system', accent: 'blue' };
+    const ICON_SPRITE_PATH = '/assets/ravan_ui/icons.svg';
 
-        // Also check for specific elements that might have the text, like the title
-        if (document.title.includes('ERPNEXT')) {
-            document.title = document.title.replace(/ERPNEXT/g, 'RavanOS');
-        }
-        if (document.title.includes('Frappe')) {
-            document.title = document.title.replace(/Frappe/g, 'Ravan');
-        }
+    const ICON_MAP = {
+        Home: 'icon-house',
+        Workspace: 'icon-grid',
+        Accounts: 'icon-ledger',
+        Accounting: 'icon-ledger',
+        CRM: 'icon-bubble',
+        Sales: 'icon-tag',
+        Selling: 'icon-tag',
+        Buying: 'icon-bag',
+        Stock: 'icon-cubes',
+        Projects: 'icon-clipboard',
+        Services: 'icon-clipboard',
+        HR: 'icon-people',
+        Payroll: 'icon-banknote',
+        Support: 'icon-lifebuoy',
+        Quality: 'icon-shield',
+        Assets: 'icon-cube',
+        Manufacturing: 'icon-gear',
+        Website: 'icon-globe',
+        Marketplace: 'icon-cart',
+        Analytics: 'icon-chart',
+        Settings: 'icon-sliders',
+        Customizations: 'icon-magic',
+        Integrations: 'icon-puzzle'
     };
 
-    // Initial replacement
-    setTimeout(() => {
-        replaceTextInSubtree(document.body);
-    }, 500); // Small delay to let initial render finish
+    const iconLookup = Object.fromEntries(
+        Object.entries(ICON_MAP).map(([label, id]) => [label.trim().toLowerCase(), id])
+    );
 
-    // Observe changes in the DOM
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true
-    });
-}); 
+    const state = { ...DEFAULT_PREFS };
+    let pendingDecorate = false;
+
+    const root = document.documentElement;
+
+    function safeParse(json) {
+        try {
+            return JSON.parse(json);
+        } catch (error) {
+            console.warn('[ravan-ui] Failed to parse preferences, resetting.', error);
+            return {};
+        }
+    }
+
+    function loadPreferences() {
+        if (!window.localStorage) {
+            return;
+        }
+        const saved = safeParse(localStorage.getItem(STORAGE_KEY) || '{}');
+        if (saved.theme) {
+            state.theme = saved.theme;
+        }
+        if (saved.accent) {
+            state.accent = saved.accent;
+        }
+    }
+
+    function persistPreferences() {
+        if (!window.localStorage) {
+            return;
+        }
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    }
+
+    function resolveSystemTheme() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+    }
+
+    function applyTheme() {
+        const targetTheme = state.theme === 'system' ? resolveSystemTheme() : state.theme;
+        root.setAttribute('data-theme', targetTheme);
+        if (document.body) {
+            document.body.setAttribute('data-theme', targetTheme);
+        }
+    }
+
+    function applyAccent() {
+        root.setAttribute('data-accent', state.accent);
+        if (document.body) {
+            document.body.setAttribute('data-accent', state.accent);
+        }
+    }
+
+    function applyBranding() {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        if (document.title) {
+            document.title = document.title
+                .replace(/ERPNEXT/gi, 'RavanOS')
+                .replace(/Frappe/gi, 'Ravan');
+        }
+
+        const brand = document.querySelector('.navbar-brand .app-logo-text');
+        if (brand && brand.textContent) {
+            brand.textContent = brand.textContent
+                .replace(/ERPNEXT/gi, 'RavanOS')
+                .replace(/Frappe/gi, 'Ravan');
+        }
+    }
+
+    function createIconElement(iconId) {
+        const iconWrapper = document.createElement('span');
+        iconWrapper.className = 'ravan-ui-icon';
+        iconWrapper.setAttribute('aria-hidden', 'true');
+        iconWrapper.innerHTML = `\n            <svg viewBox="0 0 24 24" role="presentation">\n                <use href="${ICON_SPRITE_PATH}#${iconId}" />\n            </svg>\n        `;
+        return iconWrapper;
+    }
+
+    function decorateSidebar() {
+        const links = document.querySelectorAll('.sidebar .sidebar-item .sidebar-link');
+        if (!links.length) {
+            return;
+        }
+
+        links.forEach(link => {
+            const existingIcon = link.querySelector('.ravan-ui-icon');
+            if (existingIcon) {
+                return;
+            }
+
+            const labelNode = link.querySelector('.sidebar-label, .module-link-title');
+            const labelText = (labelNode ? labelNode.textContent : link.textContent || '').trim();
+            if (!labelText) {
+                return;
+            }
+
+            const iconId = iconLookup[labelText.toLowerCase()];
+            if (!iconId) {
+                return;
+            }
+
+            // Remove default icon placeholders if present
+            const legacyIcon = link.querySelector('i, svg');
+            if (legacyIcon) {
+                legacyIcon.remove();
+            }
+
+            const iconWrapper = createIconElement(iconId);
+            link.insertBefore(iconWrapper, link.firstChild);
+        });
+    }
+
+    function decorateWorkspace() {
+        document.querySelectorAll('.workspace-card, .workspace-page .widget').forEach(card => {
+            if (!card.classList.contains('ravan-ui-elevated')) {
+                card.classList.add('ravan-ui-elevated');
+            }
+        });
+    }
+
+    function scheduleDecorate() {
+        if (pendingDecorate) {
+            return;
+        }
+        pendingDecorate = true;
+        requestAnimationFrame(() => {
+            pendingDecorate = false;
+            decorateSidebar();
+            decorateWorkspace();
+            applyBranding();
+        });
+    }
+
+    function bindFrappeHooks() {
+        if (!window.frappe) {
+            return;
+        }
+
+        if (typeof frappe.after_ajax === 'function') {
+            frappe.after_ajax(scheduleDecorate);
+        }
+
+        if (frappe.router && typeof frappe.router.on === 'function') {
+            frappe.router.on('change', scheduleDecorate);
+        }
+
+        if (frappe.desk && typeof frappe.desk.on === 'function') {
+            frappe.desk.on('page-change', scheduleDecorate);
+        }
+    }
+
+    function initObserver() {
+        if (!window.MutationObserver) {
+            return;
+        }
+
+        const observer = new MutationObserver(mutations => {
+            let shouldDecorate = false;
+            mutations.forEach(mutation => {
+                if (mutation.addedNodes && mutation.addedNodes.length) {
+                    shouldDecorate = true;
+                }
+            });
+            if (shouldDecorate) {
+                scheduleDecorate();
+            }
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    function applySystemSync() {
+        if (!window.matchMedia) {
+            return;
+        }
+        const media = window.matchMedia('(prefers-color-scheme: dark)');
+        if (typeof media.addEventListener === 'function') {
+            media.addEventListener('change', () => {
+                if (state.theme === 'system') {
+                    applyTheme();
+                }
+            });
+        } else if (typeof media.addListener === 'function') {
+            media.addListener(() => {
+                if (state.theme === 'system') {
+                    applyTheme();
+                }
+            });
+        }
+    }
+
+    function setThemePreference(preference) {
+        if (!['light', 'dark', 'system'].includes(preference)) {
+            return;
+        }
+        state.theme = preference;
+        persistPreferences();
+        applyTheme();
+    }
+
+    function setAccentPreference(accent) {
+        const accentKey = accent && accent.toLowerCase();
+        const allowed = ['blue', 'green', 'orange', 'pink'];
+        if (!allowed.includes(accentKey)) {
+            return;
+        }
+        state.accent = accentKey;
+        persistPreferences();
+        applyAccent();
+    }
+
+    function exposeAPI() {
+        window.ravanUI = {
+            setTheme: setThemePreference,
+            setAccent: setAccentPreference,
+            getPreferences: () => ({ ...state })
+        };
+    }
+
+    function boot() {
+        loadPreferences();
+        applyTheme();
+        applyAccent();
+        applyBranding();
+        scheduleDecorate();
+        bindFrappeHooks();
+        initObserver();
+        applySystemSync();
+        exposeAPI();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot, { once: true });
+    } else {
+        boot();
+    }
+})();


### PR DESCRIPTION
## Summary
- expand design tokens with Apple-inspired surface, typography, and accent primitives
- restyle desk navigation, content, and controls with translucent layering and motion polish
- replace the legacy mutation script with a theme controller and ship a matching SVG icon sprite

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6724929188330b457e864e1898ed5