### PR TITLE
Simplify Ubuntu theming and restore layout balance

### DIFF
--- a/ravan_ui/public/css/theme.css
+++ b/ravan_ui/public/css/theme.css
@@ -1,814 +1,347 @@
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap');
 @import url('variables.css');
 
 :root {
-    color-scheme: dark;
-}
-
-:root[data-theme="light"],
-body[data-theme="light"] {
     color-scheme: light;
 }
 
-:root[data-theme="dark"],
-body[data-theme="dark"] {
+:root[data-theme='dark'],
+body[data-theme='dark'] {
     color-scheme: dark;
 }
 
 body,
 .frappe-container {
-    font-family: var(--font-sans) !important;
-    background-color: var(--surface-window) !important;
-    color: var(--text-primary) !important;
-    transition: background-color var(--motion-duration-base) var(--motion-ease-standard),
-        color var(--motion-duration-base) var(--motion-ease-standard);
+    font-family: var(--font-family-sans-serif) !important;
+    background-color: var(--background-color) !important;
+    color: var(--text-color) !important;
+    line-height: 1.55;
+}
+
+body,
+.frappe-container,
+.page-container,
+.page-wrapper {
     min-height: 100vh;
-    line-height: 1.6;
-}
-
-body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    background: radial-gradient(120% 120% at 50% 0%, rgba(10, 132, 255, 0.15), transparent 60%),
-        radial-gradient(90% 140% at 0% 40%, rgba(255, 159, 10, 0.12), transparent 70%);
-    opacity: 0.7;
-    mix-blend-mode: screen;
-    z-index: 0;
-}
-
-body[data-theme="dark"]::before,
-:root[data-theme="dark"] body::before {
-    mix-blend-mode: lighten;
-    opacity: 0.35;
-}
-
-body .frappe-container,
-.frappe-container .page-container,
-.frappe-container .page-wrapper {
-    position: relative;
-    z-index: 1;
-}
-
-.page-head {
-    background: var(--surface-translucent) !important;
-    border-bottom: var(--border-width-hairline) solid var(--surface-border) !important;
-    padding: 18px clamp(16px, 3vw, 32px);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 16px;
-    backdrop-filter: blur(var(--surface-blur));
-    -webkit-backdrop-filter: blur(var(--surface-blur));
-}
-
-.page-head .page-title {
-    font-family: var(--font-sans-condensed);
-    font-size: clamp(1.4rem, 1.8vw, 2rem);
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    margin: 0;
-}
-
-.page-head .page-title .indicator {
-    display: none;
-}
-
-.page-head .page-actions,
-.page-head .page-actions .btn {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.layout-main-section {
-    display: flex;
-    flex-direction: column;
-    padding: clamp(24px, 5vw, 48px);
-    gap: clamp(18px, 4vw, 32px);
-}
-
-.layout-side-section,
-.list-sidebar {
-    padding: clamp(16px, 4vw, 28px);
 }
 
 body a,
 .frappe-container a {
-    color: var(--accent-color);
-    text-decoration: none;
-    transition: color var(--motion-duration-rapid) var(--motion-ease-standard);
+    color: var(--link-color);
+    transition: color 0.18s ease;
 }
 
-a:hover,
-a:focus {
-    color: var(--accent-color-strong);
-}
-
-::selection {
-    background: var(--selection-color);
-    color: var(--text-primary);
-}
-
-/* Layout scaffolding */
-.navbar,
-.page-head,
-.layout-main-section,
-.sidebar,
-.layout-side-section,
-.list-sidebar {
-    backdrop-filter: blur(var(--surface-blur));
-    -webkit-backdrop-filter: blur(var(--surface-blur));
+body a:hover,
+body a:focus,
+.frappe-container a:hover,
+.frappe-container a:focus {
+    color: var(--link-hover-color);
 }
 
 .navbar {
-    background-color: var(--surface-translucent) !important;
-    border-bottom: var(--border-width-hairline) solid var(--surface-border) !important;
-    box-shadow: var(--shadow-soft);
+    background-color: var(--card-bg) !important;
+    border-bottom: 1px solid var(--border-color) !important;
+    box-shadow: 0 1px 0 var(--border-color-light);
     min-height: 54px;
 }
 
 .navbar .navbar-brand .app-logo,
 .navbar .navbar-brand .app-logo-text {
-    color: var(--text-primary) !important;
-    letter-spacing: -0.01em;
+    color: var(--text-color) !important;
     font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
-.navbar .navbar-nav > li > a,
-.navbar .btn,
-.navbar .nav-item .btn {
-    border-radius: var(--control-radius-sm) !important;
-    color: var(--text-secondary) !important;
-    transition: background-color var(--motion-duration-rapid) var(--motion-ease-standard),
-        color var(--motion-duration-rapid) var(--motion-ease-standard),
-        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard);
+.page-head {
+    background-color: var(--card-bg) !important;
+    border-bottom: 1px solid var(--border-color) !important;
+    padding: calc(var(--layout-page-padding) * 0.75) var(--layout-page-padding);
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--layout-stack-gap);
 }
 
-.navbar .navbar-nav > li > a:hover,
-.navbar .btn:hover,
-.navbar .nav-item .btn:hover {
-    background: var(--icon-container-active) !important;
-    color: var(--text-primary) !important;
+.page-head .page-title {
+    margin: 0;
+    font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
-/* Sidebar */
-.sidebar {
-    width: var(--sidebar-width);
-    background: var(--surface-sidebar) !important;
-    border-right: var(--border-width-hairline) solid var(--surface-border) !important;
-    padding: clamp(20px, 4vw, 28px) clamp(16px, 3vw, 24px);
-    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04);
+.page-head .page-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--layout-stack-gap) * 0.75);
+}
+
+.layout-main-section {
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: var(--layout-section-gap);
+    padding: var(--layout-page-padding);
 }
 
-.sidebar .standard-sidebar-header {
-    color: var(--text-tertiary);
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    margin: 8px 12px;
+.layout-side-section,
+.list-sidebar {
+    padding: var(--layout-page-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--layout-section-gap);
 }
 
-.sidebar .sidebar-section {
+.sidebar,
+.workspace-sidebar {
+    width: var(--sidebar-width);
+    background-color: var(--card-bg) !important;
+    border-right: 1px solid var(--border-color) !important;
+    padding: var(--layout-page-padding) calc(var(--layout-page-padding) - 6px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--layout-section-gap);
+}
+
+.sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+}
+
+.sidebar .sidebar-section,
+.workspace-sidebar .sidebar-section {
     display: flex;
     flex-direction: column;
     gap: 4px;
 }
 
-.sidebar .sidebar-item {
-    margin-bottom: 0;
-}
-
-.sidebar .sidebar-item .sidebar-link {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 12px 14px;
-    border-radius: var(--control-radius-sm);
-    color: var(--text-secondary) !important;
-    font-weight: 500;
-    transition: background-color var(--motion-duration-rapid) var(--motion-ease-standard),
-        color var(--motion-duration-rapid) var(--motion-ease-standard),
-        transform var(--motion-duration-rapid) var(--motion-ease-emphasized);
-}
-
-.sidebar .sidebar-item .sidebar-link:focus,
-.sidebar .sidebar-item .sidebar-link:hover {
-    background: var(--surface-sidebar-active) !important;
-    color: var(--text-primary) !important;
-}
-
-.sidebar .sidebar-item.active .sidebar-link {
-    background: var(--surface-sidebar-active) !important;
-    color: var(--text-primary) !important;
-    box-shadow: 0 12px 22px rgba(10, 132, 255, 0.16);
-}
-
-.sidebar .sidebar-section + .sidebar-section {
-    margin-top: 8px;
-}
-
-.workspace-sidebar {
-    width: clamp(240px, 24vw, 320px);
-    background: var(--surface-sidebar) !important;
-    border-right: var(--border-width-hairline) solid var(--surface-border) !important;
-    padding: clamp(18px, 4vw, 28px) clamp(16px, 3vw, 24px);
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    backdrop-filter: blur(var(--surface-blur));
-    -webkit-backdrop-filter: blur(var(--surface-blur));
-}
-
-.workspace-sidebar .sidebar-section {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
+.sidebar .standard-sidebar-header,
 .workspace-sidebar .standard-sidebar-header {
     margin: 0;
-    padding: 0 8px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.14em;
+    padding: 0 calc(var(--sidebar-item-padding-x) - 6px);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--text-tertiary);
+    font-weight: 600;
+    color: var(--text-color-muted);
 }
 
+.sidebar .sidebar-item,
 .workspace-sidebar .sidebar-item {
     margin: 0;
 }
 
+.sidebar .sidebar-item .sidebar-link,
 .workspace-sidebar .sidebar-item .sidebar-link {
-    position: relative;
     display: flex;
     align-items: center;
-    gap: 14px;
-    padding: 12px 18px;
-    border-radius: 18px;
-    color: var(--text-secondary) !important;
-    font-weight: 500;
-    z-index: 0;
-    transition: background-color var(--motion-duration-rapid) var(--motion-ease-standard),
-        color var(--motion-duration-rapid) var(--motion-ease-standard),
-        transform var(--motion-duration-rapid) var(--motion-ease-emphasized);
+    gap: 0.6rem;
+    padding: var(--sidebar-item-padding-y) var(--sidebar-item-padding-x);
+    border-radius: var(--sidebar-radius);
+    color: var(--text-color-light) !important;
+    transition: background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.workspace-sidebar .sidebar-item .sidebar-link::before {
-    content: '';
-    position: absolute;
-    inset: 8px;
-    border-radius: 14px;
-    background: transparent;
-    transition: background var(--motion-duration-rapid) var(--motion-ease-standard);
-    z-index: -1;
-}
-
+.sidebar .sidebar-item .sidebar-link:hover,
+.sidebar .sidebar-item .sidebar-link:focus,
 .workspace-sidebar .sidebar-item .sidebar-link:hover,
 .workspace-sidebar .sidebar-item .sidebar-link:focus {
-    color: var(--text-primary) !important;
-    transform: translateX(4px);
+    background-color: var(--sidebar-hover-bg) !important;
+    color: var(--text-color) !important;
 }
 
-.workspace-sidebar .sidebar-item .sidebar-link:hover::before,
-.workspace-sidebar .sidebar-item .sidebar-link:focus::before {
-    background: var(--surface-sidebar-active);
-}
-
+.sidebar .sidebar-item.active .sidebar-link,
 .workspace-sidebar .sidebar-item.active .sidebar-link {
-    color: var(--text-primary) !important;
-    transform: translateX(6px);
-    box-shadow: 0 18px 32px rgba(10, 132, 255, 0.18);
-}
-
-.workspace-sidebar .sidebar-item.active .sidebar-link::before {
-    background: var(--surface-sidebar-active);
-}
-
-.workspace-sidebar .sidebar-item.active .sidebar-link::after {
-    content: '';
-    position: absolute;
-    right: 8px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 6px;
-    height: 12px;
-    border-radius: 999px;
-    background: var(--accent-color);
-    box-shadow: 0 0 14px rgba(10, 132, 255, 0.4);
-}
-
-.workspace-sidebar .sidebar-footer {
-    margin-top: auto;
-    padding-top: 12px;
-    border-top: var(--border-width-hairline) solid var(--surface-border);
-    display: grid;
-    gap: 8px;
-}
-
-.sidebar .sidebar-footer,
-.sidebar .bottom-actions {
-    margin-top: auto;
-    padding-top: 12px;
-    border-top: var(--border-width-hairline) solid var(--surface-border);
-    display: grid;
-    gap: 8px;
+    background-color: var(--sidebar-active-bg) !important;
+    color: var(--text-color) !important;
+    box-shadow: inset 3px 0 0 var(--primary-color);
 }
 
 .ravan-ui-icon {
-    width: 28px;
-    height: 28px;
-    flex: 0 0 28px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 9px;
-    background: var(--icon-container);
-    color: var(--accent-color);
-    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
-        color var(--motion-duration-rapid) var(--motion-ease-standard);
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background-color: var(--background-color-light);
+    color: var(--primary-color);
+    flex: 0 0 32px;
+    transition: background-color 0.18s ease, color 0.18s ease;
 }
 
+.sidebar .sidebar-item .sidebar-link:hover .ravan-ui-icon,
 .sidebar .sidebar-item.active .ravan-ui-icon,
-.sidebar .sidebar-item .sidebar-link:hover .ravan-ui-icon {
-    background: var(--icon-container-active);
-    color: var(--accent-color-strong);
+.workspace-sidebar .sidebar-item .sidebar-link:hover .ravan-ui-icon,
+.workspace-sidebar .sidebar-item.active .ravan-ui-icon {
+    background-color: var(--primary-color);
+    color: var(--button-text-color);
 }
 
-.ravan-ui-icon svg {
-    width: 16px;
-    height: 16px;
-    fill: currentColor;
-}
-
-/* Workspace cards & widgets */
-.workspace-page .card,
+.form-section,
+.section-card,
+.form-dashboard-section,
 .workspace-page .widget,
-.list-sidebar .sidebar-stat,
-.desk-sidebar .shortcut-card,
-.page-card,
-.widget {
-    background: var(--surface-raised) !important;
-    border: var(--border-width-hairline) solid var(--surface-border) !important;
-    border-radius: var(--control-radius-lg) !important;
-    box-shadow: var(--shadow-floating) !important;
-    padding: clamp(20px, 3vw, 28px);
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    transition: transform var(--motion-duration-rapid) var(--motion-ease-emphasized),
-        box-shadow var(--motion-duration-base) var(--motion-ease-standard),
-        border-color var(--motion-duration-base) var(--motion-ease-standard);
+.workspace-page .workspace-card {
+    background-color: var(--card-bg) !important;
+    border: 1px solid var(--card-border-color) !important;
+    border-radius: 14px !important;
+    box-shadow: var(--card-shadow) !important;
+    padding: calc(var(--layout-page-padding) - 8px) !important;
 }
 
-.workspace-page .card-body,
-.workspace-page .widget-body,
+.form-section .section-body,
+.section-card .section-body,
+.form-dashboard-section .section-body,
+.workspace-page .widget .widget-body,
 .workspace-page .workspace-card .card-body {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-
-.workspace-page .card:hover,
-.workspace-page .widget:hover,
-.desk-sidebar .shortcut-card:hover,
-.widget:hover {
-    transform: translateY(-3px);
-    box-shadow: var(--shadow-raised) !important;
-    border-color: rgba(10, 132, 255, 0.18) !important;
-}
-
-.workspace-page .card .card-title,
-.workspace-page .card .widget-title,
-.widget .widget-title,
-.section-head {
-    font-family: var(--font-sans-condensed) !important;
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    color: var(--text-primary) !important;
-}
-
-.workspace-page .section-head {
-    font-size: 1.05rem;
-    margin-bottom: 0;
-}
-
-.ravan-ui-elevated {
-    position: relative;
-    overflow: hidden;
-}
-
-.ravan-ui-elevated::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
-    opacity: 0;
-    transition: opacity var(--motion-duration-base) var(--motion-ease-standard);
-    pointer-events: none;
-}
-
-.ravan-ui-elevated:hover::after {
-    opacity: 1;
-}
-
-.ravan-launchpad {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: clamp(16px, 3vw, 28px);
-    padding: clamp(12px, 2vw, 18px);
+    gap: var(--layout-stack-gap);
 }
 
-.ravan-launchpad__item {
-    position: relative;
-    min-height: 168px;
-    padding: clamp(18px, 3vw, 24px);
-    border-radius: 28px;
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0)) border-box,
-        var(--surface-translucent);
-    border: var(--border-width-hairline) solid var(--surface-border);
-    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.14);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 14px;
-    text-align: center;
-    color: var(--text-secondary);
-    transition: transform var(--motion-duration-rapid) var(--motion-ease-emphasized),
-        box-shadow var(--motion-duration-base) var(--motion-ease-standard),
-        border-color var(--motion-duration-base) var(--motion-ease-standard);
-}
-
-body[data-theme="dark"] .ravan-launchpad__item,
-:root[data-theme="dark"] .ravan-launchpad__item {
-    background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0)) border-box,
-        rgba(28, 28, 30, 0.78);
-    border-color: rgba(255, 255, 255, 0.08);
-    box-shadow: 0 28px 42px rgba(0, 0, 0, 0.35);
-}
-
-.ravan-launchpad__item:hover {
-    transform: translateY(-6px) scale(1.01);
-    border-color: rgba(10, 132, 255, 0.26);
-    box-shadow: 0 30px 60px rgba(10, 132, 255, 0.24);
-    color: var(--text-primary);
-}
-
-.ravan-launchpad__glyph {
-    width: 76px;
-    height: 76px;
-    border-radius: 26px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(160deg, var(--icon-container-active), transparent), var(--icon-container);
-    color: var(--accent-color);
-    font-size: 1.4rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 12px 24px rgba(15, 23, 42, 0.14);
-}
-
-body[data-theme="dark"] .ravan-launchpad__glyph,
-:root[data-theme="dark"] .ravan-launchpad__glyph {
-    background: linear-gradient(160deg, rgba(10, 132, 255, 0.32), transparent), rgba(255, 255, 255, 0.06);
-    color: var(--accent-color);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 18px 34px rgba(0, 0, 0, 0.4);
-}
-
-.ravan-launchpad__glyph svg {
-    width: 34px;
-    height: 34px;
-    fill: currentColor;
-}
-
-.ravan-launchpad__label {
-    font-family: var(--font-sans-condensed);
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.ravan-launchpad__caption {
-    max-width: 220px;
-    font-size: 0.85rem;
-    line-height: 1.5;
-    color: var(--text-secondary);
-}
-
-.ravan-launchpad__item:hover .ravan-launchpad__caption {
-    color: var(--text-secondary);
-}
-
-.ravan-launchpad__badge {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    padding: 4px 10px;
-    border-radius: 999px;
-    background: var(--surface-sidebar-active);
-    color: var(--accent-color-strong);
-    font-size: 0.75rem;
-    font-weight: 600;
-}
-
-.badge,
-.indicator-pill,
-.list-tags .badge {
-    background: var(--badge-background) !important;
-    color: var(--text-secondary) !important;
-    border: none !important;
-    border-radius: var(--control-radius-sm) !important;
-    padding: 4px 10px !important;
-}
-
-/* Buttons */
-.btn,
-.form-group .btn,
-.page-actions .btn {
-    border-radius: var(--control-radius) !important;
-    font-weight: 600 !important;
-    letter-spacing: -0.01em;
-    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
-        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard),
-        transform var(--motion-duration-rapid) var(--motion-ease-standard);
-}
-
-.btn-primary,
-.btn.btn-primary {
-    background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-strong) 100%) !important;
-    color: var(--accent-on-accent) !important;
-    border: none !important;
-    box-shadow: var(--accent-shadow) !important;
-}
-
-.btn-primary:hover,
-.btn.btn-primary:hover {
-    transform: translateY(-1px);
-    filter: saturate(110%);
-}
-
-.btn-secondary,
-.btn-default,
-.btn-light {
-    background: var(--icon-container) !important;
-    color: var(--text-primary) !important;
-    border: var(--border-width-hairline) solid var(--surface-border) !important;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-.btn-secondary:hover,
-.btn-default:hover,
-.btn-light:hover {
-    background: var(--icon-container-active) !important;
-}
-
-/* Forms */
 .form-control,
 .form-select,
 .input-with-feedback,
-.control-input {
-    background: var(--input-background) !important;
-    border: var(--border-width-hairline) solid var(--input-border) !important;
-    border-radius: var(--control-radius) !important;
-    box-shadow: var(--input-shadow);
-    color: var(--text-primary) !important;
-    transition: border-color var(--motion-duration-rapid) var(--motion-ease-standard),
-        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard),
-        background var(--motion-duration-rapid) var(--motion-ease-standard);
-    padding: 10px 14px !important;
+.control-input,
+input,
+select,
+textarea {
+    background-color: var(--input-bg) !important;
+    border: 1px solid var(--input-border-color) !important;
+    color: var(--text-color) !important;
+    border-radius: 10px !important;
+    padding: 0.6rem 0.75rem !important;
+    transition: border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
 }
 
 .form-control:focus,
 .form-select:focus,
 .input-with-feedback:focus,
-.control-input:focus {
-    border-color: var(--input-border-active) !important;
-    box-shadow: 0 0 0 4px var(--accent-color-soft);
+.control-input:focus,
+input:focus,
+select:focus,
+textarea:focus {
+    background-color: var(--input-focus-bg) !important;
+    border-color: var(--input-focus-border-color) !important;
+    box-shadow: 0 0 0 2px rgba(157, 78, 221, 0.18);
     outline: none !important;
 }
 
 label,
 .form-label,
 .control-label {
-    color: var(--text-secondary) !important;
     font-weight: 500;
+    color: var(--text-color-light) !important;
 }
 
-/* Tables & list view */
+.btn-primary {
+    background: linear-gradient(135deg, var(--button-bg), var(--button-hover-bg)) !important;
+    color: var(--button-text-color) !important;
+    border: none !important;
+    transition: transform 0.18s ease, filter 0.18s ease;
+}
+
+.btn-primary:hover {
+    transform: translateY(-1px);
+    filter: brightness(1.05);
+}
+
+.table thead th,
+.list-row-head,
+.report-table thead th {
+    font-weight: 600;
+    color: var(--text-color-light) !important;
+    background-color: transparent !important;
+    border-bottom: 1px solid var(--border-color) !important;
+}
+
 .list-row,
 .report-table tbody tr,
 .table tbody tr {
-    transition: background var(--motion-duration-rapid) var(--motion-ease-standard),
-        box-shadow var(--motion-duration-rapid) var(--motion-ease-standard);
-    border-radius: var(--control-radius-sm);
-}
-
-.list-row {
-    padding: 12px 16px;
-    margin-bottom: 6px;
+    transition: background-color 0.18s ease;
 }
 
 .list-row:hover,
 .report-table tbody tr:hover,
 .table tbody tr:hover {
-    background: var(--table-row-hover) !important;
+    background-color: var(--background-color-light) !important;
 }
 
-.list-row-head,
-.report-table thead th,
-.table thead th {
-    font-weight: 600;
-    color: var(--text-secondary) !important;
-    background: transparent !important;
-    border-bottom: var(--border-width) solid var(--surface-divider) !important;
-}
-
-.list-row-container {
-    gap: 6px;
-}
-
-/* Dialogs & popovers */
-.modal,
-.dropdown-menu,
-.datepicker,
-.popover {
-    background: var(--surface-popover) !important;
-    border: var(--border-width-hairline) solid var(--surface-border-strong) !important;
-    border-radius: var(--control-radius-lg) !important;
-    box-shadow: var(--shadow-raised) !important;
-    backdrop-filter: blur(var(--surface-blur));
-    -webkit-backdrop-filter: blur(var(--surface-blur));
-    color: var(--text-primary);
-}
-
-.dropdown-menu {
-    padding: 12px;
-    display: none;
-    gap: 4px;
-}
-
-.dropdown-menu.show {
+.ravan-launchpad {
     display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--launchpad-min-width), 1fr));
+    gap: var(--launchpad-gap);
+    padding: 0;
+    margin: 0;
+    list-style: none;
 }
 
-.modal-header,
-.modal-footer {
-    border-color: var(--surface-divider) !important;
+.ravan-launchpad__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    background-color: var(--launchpad-surface);
+    border: 1px solid var(--launchpad-border);
+    border-radius: 14px;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.modal-title {
+.ravan-launchpad__item:hover,
+.ravan-launchpad__item:focus-within {
+    transform: translateY(-2px);
+    border-color: var(--launchpad-hover-border);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
+}
+
+.ravan-launchpad__glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background-color: var(--launchpad-glyph-bg);
+    color: var(--primary-color);
     font-weight: 600;
-    color: var(--text-primary) !important;
+    flex: 0 0 40px;
+    text-transform: uppercase;
 }
 
-.dropdown-item {
-    border-radius: var(--control-radius-sm);
-    color: var(--text-primary);
-    font-weight: 500;
+.ravan-launchpad__label {
+    font-weight: 600;
+    color: var(--text-color);
+    line-height: 1.3;
 }
 
-.dropdown-item:hover,
-.dropdown-item:focus {
-    background: var(--surface-sidebar-active);
-    color: var(--text-primary);
+.ravan-launchpad__caption {
+    margin-top: 0.25rem;
+    color: var(--text-color-muted);
+    font-size: 0.9rem;
+    line-height: 1.4;
 }
 
-/* Alerts & notifications */
-.alert {
-    border-radius: var(--control-radius) !important;
-    border: none !important;
-    box-shadow: var(--shadow-floating);
-}
+@media (max-width: 991px) {
+    .sidebar {
+        position: relative;
+        height: auto;
+        padding: var(--layout-page-padding);
+    }
 
-.alert-info {
-    background: rgba(10, 132, 255, 0.16) !important;
-    color: var(--text-primary) !important;
-}
-
-.alert-warning {
-    background: rgba(255, 159, 10, 0.22) !important;
-    color: var(--text-primary) !important;
-}
-
-.alert-danger {
-    background: rgba(255, 69, 58, 0.24) !important;
-    color: var(--text-primary) !important;
-}
-
-.alert-success {
-    background: rgba(48, 209, 88, 0.18) !important;
-    color: var(--text-primary) !important;
-}
-
-/* Quick lists & pills */
-.list-sidebar .list-sidebar-item,
-.list-paging-area .btn,
-.indicator-pill {
-    border-radius: var(--control-radius-sm) !important;
-}
-
-.indicator-pill.orange {
-    background: rgba(255, 159, 10, 0.16) !important;
-    color: var(--accent-on-accent) !important;
-}
-
-.indicator-pill.green {
-    background: rgba(48, 209, 88, 0.2) !important;
-    color: #0a2f14 !important;
-}
-
-/* Kanban cards */
-.kanban-card,
-.task-card {
-    background: var(--surface-raised) !important;
-    border-radius: var(--control-radius-lg) !important;
-    border: var(--border-width-hairline) solid var(--surface-border) !important;
-    box-shadow: var(--shadow-soft) !important;
-}
-
-.kanban-card:hover,
-.task-card:hover {
-    box-shadow: var(--shadow-floating) !important;
-}
-
-/* Login & onboarding */
-.login-content,
-.for-login .page-card {
-    background: var(--surface-raised) !important;
-    border-radius: var(--control-radius-lg) !important;
-    border: var(--border-width-hairline) solid var(--surface-border) !important;
-    box-shadow: var(--shadow-floating) !important;
-}
-
-/* Utility */
-.table > :not(caption) > * > * {
-    background-color: transparent !important;
-}
-
-code,
-pre,
-.monospace {
-    font-family: var(--font-mono) !important;
-}
-
-hr {
-    border-top: var(--border-width) solid var(--surface-divider) !important;
-}
-
-@supports not (backdrop-filter: blur(1px)) {
-    .navbar,
     .sidebar,
-    .page-head,
-    .layout-side-section,
-    .list-sidebar {
-        background-color: var(--surface-raised) !important;
-    }
-}
-
-/* Hide legacy chrome */
-.navbar .dropdown-help,
-.sidebar-item a[title="ERPNext Integrations"] {
-    display: none !important;
-}
-
-@media (max-width: 1200px) {
-    .sidebar {
-        width: 240px;
-    }
-}
-
-@media (max-width: 992px) {
-    .sidebar {
-        position: sticky;
-        top: 0;
+    .workspace-sidebar {
         width: 100%;
-        flex-direction: row;
-        flex-wrap: wrap;
-        gap: 12px;
     }
 
-    .sidebar .sidebar-section {
-        flex: 1 1 220px;
+    .layout-main-section {
+        padding: calc(var(--layout-page-padding) * 0.75);
     }
-}
 
-@media (max-width: 768px) {
+    .page-head {
+        padding: calc(var(--layout-page-padding) * 0.5) calc(var(--layout-page-padding) * 0.75);
+    }
+
     .ravan-launchpad {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-        padding: 12px 4px;
-    }
-
-    .ravan-launchpad__item {
-        min-height: 140px;
-        border-radius: 22px;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     }
 }

--- a/ravan_ui/public/css/variables.css
+++ b/ravan_ui/public/css/variables.css
@@ -1,180 +1,104 @@
 :root {
-    --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    --font-sans-condensed: "SF Pro Display", "SF Pro Rounded", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: "SFMono-Regular", "SF Mono", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --font-family-sans-serif: 'Ubuntu', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    --font-family-monospace: 'Ubuntu Mono', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
-    --motion-duration-rapid: 160ms;
-    --motion-duration-base: 220ms;
-    --motion-duration-slow: 360ms;
-    --motion-ease-standard: cubic-bezier(0.22, 0.61, 0.36, 1);
-    --motion-ease-emphasized: cubic-bezier(0.32, 0.72, 0, 1);
-
-    --shadow-raised: 0 30px 60px rgba(15, 23, 42, 0.18);
-    --shadow-floating: 0 18px 40px rgba(15, 23, 42, 0.14);
-    --shadow-soft: 0 1px 3px rgba(15, 23, 42, 0.08);
-
-    --surface-blur: 26px;
-    --border-width-hairline: 0.5px;
-    --border-width: 1px;
-
-    --control-radius-sm: 10px;
-    --control-radius: 12px;
-    --control-radius-lg: 18px;
-
-    --density-tight: 12px;
-    --density-regular: 16px;
-    --density-loose: 24px;
-
-    --sidebar-width: 268px;
-
-    --accent-color: #0a84ff;
-    --accent-color-strong: #0060df;
-    --accent-color-soft: rgba(10, 132, 255, 0.16);
-    --accent-on-accent: #ffffff;
-    --accent-shadow: 0 0 0 1px rgba(10, 132, 255, 0.18), 0 10px 24px rgba(10, 132, 255, 0.24);
-    --surface-window: #050509;
-    --surface-base: rgba(28, 28, 30, 0.82);
-    --surface-raised: rgba(37, 37, 39, 0.82);
-    --surface-popover: rgba(44, 44, 46, 0.88);
-    --surface-translucent: rgba(29, 29, 31, 0.76);
-    --surface-divider: rgba(84, 84, 88, 0.3);
-    --surface-divider-strong: rgba(199, 199, 204, 0.28);
-    --surface-border: rgba(255, 255, 255, 0.08);
-    --surface-border-strong: rgba(255, 255, 255, 0.18);
-    --surface-sidebar: rgba(22, 22, 24, 0.78);
-    --surface-sidebar-active: rgba(10, 132, 255, 0.22);
-
-    --text-primary: rgba(255, 255, 255, 0.92);
-    --text-secondary: rgba(235, 235, 245, 0.66);
-    --text-tertiary: rgba(235, 235, 245, 0.42);
-    --text-quaternary: rgba(235, 235, 245, 0.28);
-    --text-inverse: rgba(17, 17, 17, 0.92);
-
-    --input-background: rgba(44, 44, 46, 0.68);
-    --input-border: rgba(255, 255, 255, 0.06);
-    --input-border-active: rgba(10, 132, 255, 0.7);
-    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 2px rgba(0, 0, 0, 0.4);
-
-    --table-row-hover: rgba(10, 132, 255, 0.18);
-    --pill-background: rgba(235, 235, 245, 0.16);
-    --badge-background: rgba(235, 235, 245, 0.18);
-
-    --icon-container: rgba(235, 235, 245, 0.12);
-    --icon-container-active: rgba(10, 132, 255, 0.26);
-
-    --selection-color: rgba(10, 132, 255, 0.24);
-    --selection-outline: rgba(10, 132, 255, 0.38);
-
-[data-accent="blue"] {
-    --accent-color: #0a84ff;
-    --accent-color-strong: #0060df;
-    --accent-color-soft: rgba(10, 132, 255, 0.16);
-    --accent-on-accent: #ffffff;
-    --accent-shadow: 0 0 0 1px rgba(10, 132, 255, 0.18), 0 10px 24px rgba(10, 132, 255, 0.24);
+    --layout-page-padding: clamp(16px, 2vw, 28px);
+    --layout-section-gap: clamp(14px, 2vw, 24px);
+    --layout-stack-gap: clamp(10px, 1.4vw, 18px);
+    --sidebar-width: 260px;
+    --sidebar-radius: 12px;
+    --sidebar-item-padding-y: 0.65rem;
+    --sidebar-item-padding-x: 1rem;
+    --launchpad-min-width: 220px;
+    --launchpad-gap: clamp(16px, 2vw, 24px);
 }
 
-[data-accent="green"] {
-    --accent-color: #30d158;
-    --accent-color-strong: #248a3d;
-    --accent-color-soft: rgba(48, 209, 88, 0.18);
-    --accent-on-accent: #031d0b;
-    --accent-shadow: 0 0 0 1px rgba(48, 209, 88, 0.18), 0 10px 24px rgba(48, 209, 88, 0.24);
+[data-theme='light'] {
+    --primary-color: #4e0091;
+    --primary-color-hover: #3a006a;
+    --primary-color-light: #f2e6ff;
+    --primary-color-light-hover: #e6d9f2;
+
+    --text-color: #212529;
+    --text-color-light: #5a5a5a;
+    --text-color-muted: #8d8d8d;
+
+    --background-color: #ffffff;
+    --background-color-light: #f0f2f5;
+    --background-color-dark: #e9ecef;
+
+    --border-color: #dee2e6;
+    --border-color-light: #f1f1f1;
+
+    --card-bg: #ffffff;
+    --card-border-color: var(--border-color);
+    --card-shadow: 0 12px 24px rgba(33, 37, 41, 0.08);
+
+    --button-bg: var(--primary-color);
+    --button-text-color: #ffffff;
+    --button-hover-bg: var(--primary-color-hover);
+
+    --input-bg: #fdfdfd;
+    --input-border-color: #ced4da;
+    --input-focus-bg: #ffffff;
+    --input-focus-border-color: var(--primary-color);
+
+    --modal-bg: #ffffff;
+    --modal-shadow: 0 16px 40px rgba(33, 37, 41, 0.18);
+
+    --link-color: var(--primary-color);
+    --link-hover-color: var(--primary-color-hover);
+
+    --sidebar-hover-bg: rgba(78, 0, 145, 0.08);
+    --sidebar-active-bg: rgba(78, 0, 145, 0.16);
+
+    --launchpad-surface: #ffffff;
+    --launchpad-border: rgba(78, 0, 145, 0.16);
+    --launchpad-hover-border: rgba(78, 0, 145, 0.28);
+    --launchpad-glyph-bg: rgba(78, 0, 145, 0.14);
 }
 
-[data-accent="orange"] {
-    --accent-color: #ff9f0a;
-    --accent-color-strong: #c36a00;
-    --accent-color-soft: rgba(255, 159, 10, 0.2);
-    --accent-on-accent: #2b1700;
-    --accent-shadow: 0 0 0 1px rgba(255, 159, 10, 0.24), 0 10px 24px rgba(255, 159, 10, 0.28);
-}
+[data-theme='dark'] {
+    --primary-color: #9d4edd;
+    --primary-color-hover: #b370f2;
+    --primary-color-light: #3c1e5b;
+    --primary-color-light-hover: #4a2a6f;
 
-[data-accent="pink"] {
-    --accent-color: #ff2d55;
-    --accent-color-strong: #c01333;
-    --accent-color-soft: rgba(255, 45, 85, 0.18);
-    --accent-on-accent: #2a030a;
-    --accent-shadow: 0 0 0 1px rgba(255, 45, 85, 0.22), 0 10px 24px rgba(255, 45, 85, 0.3);
-}
+    --text-color: #e0e0e0;
+    --text-color-light: #b0b0b0;
+    --text-color-muted: #7e7e7e;
 
-[data-theme="light"] {
-    --surface-window: #f5f6f9;
-    --surface-base: rgba(255, 255, 255, 0.86);
-    --surface-raised: rgba(255, 255, 255, 0.92);
-    --surface-popover: rgba(255, 255, 255, 0.97);
-    --surface-translucent: rgba(255, 255, 255, 0.76);
-    --surface-divider: rgba(60, 60, 67, 0.18);
-    --surface-divider-strong: rgba(60, 60, 67, 0.28);
-    --surface-border: rgba(30, 41, 59, 0.12);
-    --surface-border-strong: rgba(30, 41, 59, 0.24);
-    --surface-sidebar: rgba(246, 247, 250, 0.84);
-    --surface-sidebar-active: rgba(10, 132, 255, 0.12);
+    --background-color: #121212;
+    --background-color-light: #2a2a2a;
+    --background-color-dark: #2c2c2c;
 
-    --text-primary: rgba(17, 17, 17, 0.92);
-    --text-secondary: rgba(60, 60, 67, 0.72);
-    --text-tertiary: rgba(60, 60, 67, 0.5);
-    --text-quaternary: rgba(60, 60, 67, 0.32);
-    --text-inverse: rgba(255, 255, 255, 0.94);
+    --border-color: #3c3c3c;
+    --border-color-light: #2a2a2a;
 
-    --input-background: rgba(255, 255, 255, 0.68);
-    --input-border: rgba(30, 41, 59, 0.12);
-    --input-border-active: rgba(10, 132, 255, 0.6);
-    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 2px rgba(15, 23, 42, 0.12);
+    --card-bg: #1e1e1e;
+    --card-border-color: var(--border-color);
+    --card-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
 
-    --table-row-hover: rgba(10, 132, 255, 0.08);
-    --pill-background: rgba(60, 60, 67, 0.12);
-    --badge-background: rgba(60, 60, 67, 0.14);
+    --button-bg: var(--primary-color);
+    --button-text-color: #ffffff;
+    --button-hover-bg: var(--primary-color-hover);
 
-    --icon-container: rgba(60, 60, 67, 0.08);
-    --icon-container-active: rgba(10, 132, 255, 0.14);
+    --input-bg: #252525;
+    --input-border-color: #495057;
+    --input-focus-bg: #2c2c2c;
+    --input-focus-border-color: var(--primary-color);
 
-    --selection-color: rgba(10, 132, 255, 0.14);
-    --selection-outline: rgba(10, 132, 255, 0.28);
-}
+    --modal-bg: #1e1e1e;
+    --modal-shadow: 0 20px 48px rgba(0, 0, 0, 0.65);
 
-[data-theme="dark"] {
-    --surface-window: #050509;
-    --surface-base: rgba(28, 28, 30, 0.82);
-    --surface-raised: rgba(37, 37, 39, 0.82);
-    --surface-popover: rgba(44, 44, 46, 0.88);
-    --surface-translucent: rgba(29, 29, 31, 0.76);
-    --surface-divider: rgba(84, 84, 88, 0.3);
-    --surface-divider-strong: rgba(199, 199, 204, 0.28);
-    --surface-border: rgba(255, 255, 255, 0.08);
-    --surface-border-strong: rgba(255, 255, 255, 0.18);
-    --surface-sidebar: rgba(22, 22, 24, 0.78);
-    --surface-sidebar-active: rgba(10, 132, 255, 0.22);
+    --link-color: var(--primary-color);
+    --link-hover-color: var(--primary-color-hover);
 
-    --text-primary: rgba(255, 255, 255, 0.92);
-    --text-secondary: rgba(235, 235, 245, 0.66);
-    --text-tertiary: rgba(235, 235, 245, 0.42);
-    --text-quaternary: rgba(235, 235, 245, 0.28);
-    --text-inverse: rgba(17, 17, 17, 0.92);
+    --sidebar-hover-bg: rgba(157, 78, 221, 0.16);
+    --sidebar-active-bg: rgba(157, 78, 221, 0.24);
 
-    --input-background: rgba(44, 44, 46, 0.68);
-    --input-border: rgba(255, 255, 255, 0.06);
-    --input-border-active: rgba(10, 132, 255, 0.7);
-    --input-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 2px rgba(0, 0, 0, 0.4);
-
-    --table-row-hover: rgba(10, 132, 255, 0.18);
-    --pill-background: rgba(235, 235, 245, 0.16);
-    --badge-background: rgba(235, 235, 245, 0.18);
-
-    --icon-container: rgba(235, 235, 245, 0.12);
-    --icon-container-active: rgba(10, 132, 255, 0.26);
-
-    --selection-color: rgba(10, 132, 255, 0.24);
-    --selection-outline: rgba(10, 132, 255, 0.38);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) {
-        color-scheme: dark;
-    }
-}
-
-@media (prefers-color-scheme: light) {
-    :root:not([data-theme="dark"]) {
-        color-scheme: light;
-    }
+    --launchpad-surface: rgba(35, 35, 35, 0.95);
+    --launchpad-border: rgba(157, 78, 221, 0.24);
+    --launchpad-hover-border: rgba(195, 144, 239, 0.36);
+    --launchpad-glyph-bg: rgba(157, 78, 221, 0.24);
 }


### PR DESCRIPTION
## Summary
- reintroduce a restrained Ubuntu-driven base theme with balanced spacing and typography variables
- refine desk and workspace sidebar treatments to keep hover and active states consistent without overwhelming shadows
- rebuild the workspace shortcut grid styling so tiles stay aligned and readable across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d690eca52c833090f8dd52a0c1f890